### PR TITLE
Default to normalized values.

### DIFF
--- a/src/mpeInstrument/index.js
+++ b/src/mpeInstrument/index.js
@@ -64,9 +64,9 @@ export function mpeInstrument(options) {
    * instrument.activeNotes();
    * // => [ { noteNumber: 60,
    * //        channel: 2,
-   * //        noteOnVelocity: 127,
-   * //        pitchBend: 8192,
-   * //        timbre: 8192,
+   * //        noteOnVelocity: 1,
+   * //        pitchBend: 0,
+   * //        timbre: 0.5,
    * //        pressure: 0 } ]
    *
    * @memberof mpeInstrument
@@ -93,9 +93,9 @@ export function mpeInstrument(options) {
    * instrument.activeNotes();
    * // => [ { noteNumber: 60,
    * //        channel: 2,
-   * //        noteOnVelocity: 127,
-   * //        pitchBend: 8192,
-   * //        timbre: 8192,
+   * //        noteOnVelocity: 1,
+   * //        pitchBend: 0,
+   * //        timbre: 0.5,
    * //        pressure: 0 } ]
    *
    * instrument.clear();

--- a/src/mpeInstrument/index.js
+++ b/src/mpeInstrument/index.js
@@ -36,10 +36,16 @@ import rootReducer from './reducers';
  *
  */
 export function mpeInstrument(options) {
+  const defaults = {
+    log: false,
+    normalize: true,
+    pitch: false,
+  };
+  const defaultedOptions = Object.assign({}, defaults, options);
   const middlewares = [
-    options && options.normalize && normalizer,
-    options && options.pitch && pitchConverter(options.pitch),
-    options && options.log && logger,
+    defaultedOptions.normalize && normalizer,
+    defaultedOptions.pitch && pitchConverter(options.pitch),
+    defaultedOptions.log && logger,
   ].filter(f => f);
   const store = createStore(rootReducer, applyMiddleware(...middlewares));
 

--- a/test/functional/mpeInstrument.test.js
+++ b/test/functional/mpeInstrument.test.js
@@ -216,7 +216,7 @@ describe('mpeInstrument', () => {
   });
   describe('#processMidiMessage()', () => {
     beforeEach(() => {
-      instrument = mpeInstrument();
+      instrument = mpeInstrument({ normalize: false });
     });
     it('creates an active note given a note on', () => {
       instrument.processMidiMessage(NOTE_ON_1);


### PR DESCRIPTION
Aim:
Make the library usable without worrying about scaling unsigned 7- or 14-bit integers

Old:
```
const instrument = mpeInstrument();

instrument.activeNotes();
// => []

instrument.processMidiMessage([145, 60, 127]);
instrument.activeNotes();
// => [ { noteNumber: 60,
//        channel: 2,
//        noteOnVelocity: 127,
//        pitchBend: 8192,
//        timbre: 8192,
//        pressure: 0 } ]
```

New:
```
const instrument = mpeInstrument();
instrument.processMidiMessage([145, 60, 127]);
instrument.activeNotes();
// => [ { noteNumber: 60,
//        channel: 2,
//        noteOnVelocity: 1,
//        pitchBend: 0,
//        timbre: 0.5,
//        pressure: 0 } ]
```