### PR TITLE
Replace redux middleware for active note conversions.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,6 +10,10 @@
     "sourceType": "module",
   },
   "rules": {
+    "arrow-parens": [
+      "error",
+      "as-needed",
+    ],
     "comma-dangle": [
       "error",
       "always-multiline",

--- a/package.json
+++ b/package.json
@@ -40,36 +40,39 @@
     "serve": "python -m SimpleHTTPServer 8000"
   },
   "dependencies": {
-    "redux": "^3.5.2"
+    "redux": "3.5.2"
   },
   "devDependencies": {
-    "babel": "^6.5.2",
-    "babel-cli": "^6.10.1",
-    "babel-core": "^6.9.1",
-    "babel-loader": "^6.2.4",
-    "babel-preset-es2015": "^6.9.0",
-    "chai": "^3.5.0",
-    "concat-stream": "^1.5.1",
-    "doctrine": "^1.2.2",
-    "documentation": "^4.0.0-beta5",
-    "documentation-theme-utils": "^3.0.0",
-    "eslint": "^2.13.1",
-    "git-directory-deploy": "^1.5.0",
-    "highlight.js": "^9.4.0",
-    "html-webpack-plugin": "^2.21.0",
-    "jsdoc": "^3.4.0",
-    "lodash": "^4.13.1",
-    "mocha": "^2.5.3",
-    "remark": "^5.0.1",
-    "remark-html": "^4.0.0",
-    "sinon": "^1.17.4",
-    "sinon-chai": "^2.8.0",
-    "unist-util-visit": "^1.1.0",
-    "vinyl": "^1.1.1",
-    "vinyl-fs": "^2.4.3",
-    "webpack": "^1.13.1"
+    "babel": "6.5.2",
+    "babel-cli": "6.10.1",
+    "babel-core": "6.9.1",
+    "babel-loader": "6.2.4",
+    "babel-preset-es2015": "6.9.0",
+    "chai": "3.5.0",
+    "concat-stream": "1.5.1",
+    "doctrine": "1.2.2",
+    "documentation": "4.0.0-beta5",
+    "documentation-theme-utils": "3.0.0",
+    "eslint": "2.13.1",
+    "git-directory-deploy": "1.5.0",
+    "highlight.js": "9.4.0",
+    "html-webpack-plugin": "2.21.0",
+    "jsdoc": "3.4.0",
+    "lodash": "4.13.1",
+    "mocha": "2.5.3",
+    "mocha-logger": "1.0.5",
+    "remark": "5.0.1",
+    "remark-html": "4.0.0",
+    "sinon": "1.17.4",
+    "sinon-chai": "2.8.0",
+    "unist-util-visit": "1.1.0",
+    "vinyl": "1.1.1",
+    "vinyl-fs": "2.4.3",
+    "webpack": "1.13.1"
   },
   "babel": {
-    "presets": ["es2015"]
+    "presets": [
+      "es2015"
+    ]
   }
 }

--- a/src/mpeInstrument/actions.js
+++ b/src/mpeInstrument/actions.js
@@ -3,11 +3,11 @@ import * as defaults from './constants/defaults';
 import * as types from './constants/actionTypes';
 import { dataBytesToUint14 } from './utils/dataByteUtils';
 
-export function clearActiveNotes() {
-  return { type: types.ALL_NOTES_OFF };
-}
+export const clearActiveNotes = () => ({
+  type: types.ALL_NOTES_OFF,
+});
 
-export function generateMidiActions(midiMessage, currentStateCallback) {
+export const generateMidiActions = (midiMessage, currentStateCallback) => {
   const channel = statusByteToChannel(midiMessage[0]);
   const dataBytes = midiMessage.slice(1);
 
@@ -20,9 +20,9 @@ export function generateMidiActions(midiMessage, currentStateCallback) {
     return [mainAction, { type: types.NOTE_RELEASED }];
   }
   return [mainAction];
-}
+};
 
-function deriveActionType(midiMessageType, channel, dataBytes) {
+const deriveActionType = (midiMessageType, channel, dataBytes) => {
   switch (midiMessageType) {
     case types.NOTE_ON:
       // A note on with velocity 0 is a treated as a note off
@@ -34,9 +34,9 @@ function deriveActionType(midiMessageType, channel, dataBytes) {
       if (dataBytes[0] === 123 && channel === 1) return types.ALL_NOTES_OFF;
   }
   return midiMessageType;
-}
+};
 
-function deriveTypeSpecificData(baseData, currentStateCallback) {
+const deriveTypeSpecificData = (baseData, currentStateCallback) => {
   const { type, midiMessageType, channel, dataBytes } = baseData;
   switch (type) {
     case types.NOTE_ON: {
@@ -57,4 +57,4 @@ function deriveTypeSpecificData(baseData, currentStateCallback) {
     case types.CHANNEL_PRESSURE:
       return { pressure: dataBytesToUint14(dataBytes) };
   }
-}
+};

--- a/src/mpeInstrument/index.js
+++ b/src/mpeInstrument/index.js
@@ -35,7 +35,7 @@ import rootReducer from './reducers';
  * Helmholtz notation eg. `c'` when set to `'helmholtz'`
  * @return {Object} Instance representing an MPE compatible instrument
  */
-export const mpeInstrument = (options) => {
+export const mpeInstrument = options => {
   const defaults = {
     log: false,
     normalize: true,
@@ -125,7 +125,7 @@ export const mpeInstrument = (options) => {
    * @param {Uint8Array} midiMessage An MPE MIDI message
    * @return {undefined}
    */
-  const processMidiMessage = (midiMessage) => {
+  const processMidiMessage = midiMessage => {
     const actions = generateMidiActions(midiMessage, store.getState);
     actions.forEach(store.dispatch);
   };
@@ -145,7 +145,7 @@ export const mpeInstrument = (options) => {
    * @param {function} callback Callback for active note changes
    * @return {function} Unsubscribe the callback
    */
-  const subscribe = (callback) => {
+  const subscribe = callback => {
     let currentActiveNotes = rawActiveNotes();
     return store.subscribe(() => {
       let previousActiveNotes = currentActiveNotes;

--- a/src/mpeInstrument/index.js
+++ b/src/mpeInstrument/index.js
@@ -1,6 +1,7 @@
-import { createStore, applyMiddleware } from 'redux';
+import { createStore, applyMiddleware, compose } from 'redux';
 import { generateMidiActions, clearActiveNotes } from './actions';
-import { logger, normalizer, pitchConverter } from './middlewares';
+import { logger } from './middlewares';
+import { normalizeAction, addPitch } from './utils/actionUtils';
 import rootReducer from './reducers';
 
 /**
@@ -42,12 +43,16 @@ export function mpeInstrument(options) {
     pitch: false,
   };
   const defaultedOptions = Object.assign({}, defaults, options);
+  const formatNote = compose(...[
+    defaultedOptions.normalize && normalizeAction,
+    defaultedOptions.pitch && addPitch(options.pitch),
+  ].filter(f => f));
+  const formatActiveNotes = notes => notes.map(formatNote);
   const middlewares = [
-    defaultedOptions.normalize && normalizer,
-    defaultedOptions.pitch && pitchConverter(options.pitch),
-    defaultedOptions.log && logger,
+    defaultedOptions.log && logger(formatActiveNotes),
   ].filter(f => f);
   const store = createStore(rootReducer, applyMiddleware(...middlewares));
+  const rawActiveNotes = () => store.getState().activeNotes;
 
   /**
    * Lists active notes of the `mpeInstrument` instance
@@ -74,9 +79,7 @@ export function mpeInstrument(options) {
    * @return {Array} Active note objects
    * @method activeNotes
    */
-  function activeNotes() {
-    return store.getState().activeNotes;
-  }
+  const activeNotes = () => formatActiveNotes(rawActiveNotes());
 
   /**
    * Clears all active notes
@@ -106,9 +109,7 @@ export function mpeInstrument(options) {
    * @instance
    * @return {undefined}
    */
-  function clear() {
-    store.dispatch(clearActiveNotes());
-  }
+  const clear = () => store.dispatch(clearActiveNotes());
 
   /**
    * Reads an MPE message and updates `mpeInstrument` state
@@ -125,10 +126,10 @@ export function mpeInstrument(options) {
    * @param {Uint8Array} midiMessage An MPE MIDI message
    * @return {undefined}
    */
-  function processMidiMessage(midiMessage) {
+  const processMidiMessage = (midiMessage) => {
     const actions = generateMidiActions(midiMessage, store.getState);
     actions.forEach(store.dispatch);
-  }
+  };
 
   /**
    * Subscribes a callback to changes to the instance's active notes
@@ -145,16 +146,16 @@ export function mpeInstrument(options) {
    * @param {function} callback Callback for active note changes
    * @return {function} Unsubscribe the callback
    */
-  function subscribe(callback) {
-    let currentActiveNotes = this.activeNotes();
+  const subscribe = (callback) => {
+    let currentActiveNotes = rawActiveNotes();
     return store.subscribe(() => {
       let previousActiveNotes = currentActiveNotes;
-      currentActiveNotes = this.activeNotes();
+      currentActiveNotes = rawActiveNotes();
       if (currentActiveNotes !== previousActiveNotes) {
-        callback(this.activeNotes());
+        callback(activeNotes());
       }
     });
-  }
+  };
 
   return {
     processMidiMessage,

--- a/src/mpeInstrument/index.js
+++ b/src/mpeInstrument/index.js
@@ -36,7 +36,7 @@ import rootReducer from './reducers';
  * @return {Object} Instance representing an MPE compatible instrument
  *
  */
-export function mpeInstrument(options) {
+export const mpeInstrument = (options) => {
   const defaults = {
     log: false,
     normalize: true,
@@ -163,4 +163,4 @@ export function mpeInstrument(options) {
     activeNotes,
     subscribe,
   };
-}
+};

--- a/src/mpeInstrument/index.js
+++ b/src/mpeInstrument/index.js
@@ -34,7 +34,6 @@ import rootReducer from './reducers';
  * uses scientific notation eg. `C4` when `true` or `'scientific'`, uses
  * Helmholtz notation eg. `c'` when set to `'helmholtz'`
  * @return {Object} Instance representing an MPE compatible instrument
- *
  */
 export const mpeInstrument = (options) => {
   const defaults = {

--- a/src/mpeInstrument/middlewares.js
+++ b/src/mpeInstrument/middlewares.js
@@ -1,26 +1,13 @@
-import { normalizeAction, addScientificPitch, addHelmholtzPitch } from './utils/actionUtils';
-
 let currentActiveNotes;
 
 /* eslint-disable no-console */
-export const logger = store => next => action => {
+export const logger = formatActiveNotes => store => next => action => {
   let result = next(action);
   let previousActiveNotes = currentActiveNotes;
   currentActiveNotes = store.getState().activeNotes;
   if (currentActiveNotes !== previousActiveNotes) {
-    console.log('active notes:', currentActiveNotes);
+    console.log('active notes:', formatActiveNotes(currentActiveNotes));
   }
   return result;
 };
 /* eslint-enable no-console */
-
-export const normalizer = store => next => action => {
-  return next(normalizeAction(action));
-};
-
-export const pitchConverter = conversionType => store => next => action => {
-  const actionModifier = conversionType === 'helmholtz'
-    ? addHelmholtzPitch
-    : addScientificPitch;
-  return next(actionModifier(action));
-};

--- a/src/mpeInstrument/reducers/activeNotes.js
+++ b/src/mpeInstrument/reducers/activeNotes.js
@@ -20,14 +20,14 @@ const activeNotes = (state = [], action) => {
     case types.CHANNEL_PRESSURE:
     case types.TIMBRE: {
       const noteIndexes = findActiveNoteIndexesByChannel(state, action);
-      noteIndexes.forEach((noteIndex) => {
+      noteIndexes.forEach(noteIndex => {
         state = [...state.slice(0, noteIndex), activeNote(state[noteIndex], action), ...state.slice(noteIndex + 1)];
       });
       return state;
     }
     case types.NOTE_RELEASED:
       return state.length ?
-        state.filter((activeNote) => activeNote.noteState !== noteStates.OFF) :
+        state.filter(activeNote => activeNote.noteState !== noteStates.OFF) :
         state;
     case types.ALL_NOTES_OFF:
       return [];

--- a/src/mpeInstrument/reducers/activeNotes.js
+++ b/src/mpeInstrument/reducers/activeNotes.js
@@ -3,7 +3,7 @@ import * as defaults from '../constants/defaults';
 import * as noteStates from '../constants/noteStates';
 import { findActiveNoteIndex, findActiveNoteIndexesByChannel } from '../utils/activeNoteUtils';
 
-export default function activeNotes(state = [], action) {
+const activeNotes = (state = [], action) => {
   if (!types[action.type]) {
     return state;
   }
@@ -33,9 +33,9 @@ export default function activeNotes(state = [], action) {
       return [];
   }
   return state;
-}
+};
 
-function activeNote(state = defaults.ACTIVE_NOTE, action) {
+const activeNote = (state = defaults.ACTIVE_NOTE, action) => {
   const { noteNumber, channel, channelScope, noteOnVelocity, noteOffVelocity,
     pitch, pitchBend, pressure, timbre } = action;
   switch(action.type) {
@@ -51,4 +51,6 @@ function activeNote(state = defaults.ACTIVE_NOTE, action) {
       return Object.assign({}, state, { timbre });
   }
   return state;
-}
+};
+
+export default activeNotes;

--- a/src/mpeInstrument/reducers/channelScopes.js
+++ b/src/mpeInstrument/reducers/channelScopes.js
@@ -1,15 +1,15 @@
 import * as types from '../constants/actionTypes';
 import * as defaults from '../constants/defaults';
 
-export default function channelScopes(state = defaults.CHANNEL_SCOPES, action) {
+const channelScopes = (state = defaults.CHANNEL_SCOPES, action) => {
   if (!types[action.type]) {
     return state;
   }
   const { channel } = action;
   return Object.assign({}, state, { [channel]: channelScope(state[channel], action) });
-}
+};
 
-function channelScope(state, action) {
+const channelScope = (state, action) => {
   switch (action.type) {
     case types.PITCH_BEND:
       return Object.assign({}, state, { pitchBend: action.pitchBend });
@@ -22,4 +22,6 @@ function channelScope(state, action) {
       return defaults.CHANNEL_SCOPE;
   }
   return state;
-}
+};
+
+export default channelScopes;

--- a/src/mpeInstrument/utils/actionUtils.js
+++ b/src/mpeInstrument/utils/actionUtils.js
@@ -6,7 +6,7 @@ export const normalizeAction = action => {
     action.channelScope = normalizeNote(action.channelScope);
   }
   return normalizeNote(action);
-}
+};
 
 export const addScientificPitch = action =>
   typeof action.noteNumber === 'undefined'

--- a/src/mpeInstrument/utils/actionUtils.js
+++ b/src/mpeInstrument/utils/actionUtils.js
@@ -17,3 +17,9 @@ export function addHelmholtzPitch(action) {
   if (typeof action.noteNumber === 'undefined') return action;
   return Object.assign({}, action, { pitch: toHelmholtzPitch(action.noteNumber) });
 }
+
+export function addPitch(conversionType) {
+  return conversionType === 'helmholtz'
+    ? addHelmholtzPitch
+    : addScientificPitch;
+}

--- a/src/mpeInstrument/utils/actionUtils.js
+++ b/src/mpeInstrument/utils/actionUtils.js
@@ -1,25 +1,24 @@
 import { normalizeNote } from './activeNoteUtils';
 import { toScientificPitch, toHelmholtzPitch } from './noteNumberUtils';
 
-export function normalizeAction(action) {
+export const normalizeAction = action => {
   if (action.channelScope) {
     action.channelScope = normalizeNote(action.channelScope);
   }
   return normalizeNote(action);
 }
 
-export function addScientificPitch(action) {
-  if (typeof action.noteNumber === 'undefined') return action;
-  return Object.assign({}, action, { pitch: toScientificPitch(action.noteNumber) });
-}
+export const addScientificPitch = action =>
+  typeof action.noteNumber === 'undefined'
+    ? action
+    : Object.assign({}, action, { pitch: toScientificPitch(action.noteNumber) });
 
-export function addHelmholtzPitch(action) {
-  if (typeof action.noteNumber === 'undefined') return action;
-  return Object.assign({}, action, { pitch: toHelmholtzPitch(action.noteNumber) });
-}
+export const addHelmholtzPitch = action =>
+  typeof action.noteNumber === 'undefined'
+    ? action
+    : Object.assign({}, action, { pitch: toHelmholtzPitch(action.noteNumber) });
 
-export function addPitch(conversionType) {
-  return conversionType === 'helmholtz'
+export const addPitch = conversionType =>
+  conversionType === 'helmholtz'
     ? addHelmholtzPitch
     : addScientificPitch;
-}

--- a/src/mpeInstrument/utils/activeNoteUtils.js
+++ b/src/mpeInstrument/utils/activeNoteUtils.js
@@ -9,21 +9,19 @@ const NORMALIZE_NOTE_TRANSFORMATIONS = {
   timbre: int14ToUnsignedFloat,
 };
 
-export function normalizeNote(note) {
-  return transformObject(note, NORMALIZE_NOTE_TRANSFORMATIONS);
-}
+export const normalizeNote = (note) =>
+  transformObject(note, NORMALIZE_NOTE_TRANSFORMATIONS);
 
-export function findActiveNoteIndex(state, action) {
+export const findActiveNoteIndex = (state, action) => {
   const { channel, noteNumber } = action;
   return state.findIndex((activeNote) =>
     activeNote.channel === channel && activeNote.noteNumber === noteNumber
   );
-}
+};
 
-export function findActiveNoteIndexesByChannel(state, action) {
-  return state.reduce(
+export const findActiveNoteIndexesByChannel = (state, action) =>
+  state.reduce(
     (indexes, activeNote, index) =>
       activeNote.channel === action.channel ? [...indexes, index] : indexes,
       []
   );
-}

--- a/src/mpeInstrument/utils/activeNoteUtils.js
+++ b/src/mpeInstrument/utils/activeNoteUtils.js
@@ -9,12 +9,12 @@ const NORMALIZE_NOTE_TRANSFORMATIONS = {
   timbre: int14ToUnsignedFloat,
 };
 
-export const normalizeNote = (note) =>
+export const normalizeNote = note =>
   transformObject(note, NORMALIZE_NOTE_TRANSFORMATIONS);
 
 export const findActiveNoteIndex = (state, action) => {
   const { channel, noteNumber } = action;
-  return state.findIndex((activeNote) =>
+  return state.findIndex(activeNote =>
     activeNote.channel === channel && activeNote.noteNumber === noteNumber
   );
 };

--- a/src/mpeInstrument/utils/dataByteUtils.js
+++ b/src/mpeInstrument/utils/dataByteUtils.js
@@ -4,7 +4,7 @@
  * @param {uint8} input Input 7-bit integer.
  * @returns {uint16} Scaled 14-bit integer.
  */
-export const scale7To14Bit = (input) => {
+export const scale7To14Bit = input => {
   if (input > 127) {
     throw new RangeError(
       `scale7To14Bit takes a 7-bit integer.\n` +
@@ -23,9 +23,9 @@ export const scale7To14Bit = (input) => {
  * @param {uint8} midiDataBytes The encoded data from a standard MIDI message.
  * @returns {uint16} Normalized 14-bit integer representation of the inputs.
  */
-export const dataBytesToUint14 = (midiDataBytes) => {
+export const dataBytesToUint14 = midiDataBytes => {
   // Discard identifier bit.
-  const midiDataByteContents = midiDataBytes.map((dataByte) => 127 & dataByte);
+  const midiDataByteContents = midiDataBytes.map(dataByte => 127 & dataByte);
   switch (midiDataBytes.length) {
     case 1:
       // With one 7-bit value, scale to a 14-bit integer.

--- a/src/mpeInstrument/utils/noteNumberUtils.js
+++ b/src/mpeInstrument/utils/noteNumberUtils.js
@@ -13,38 +13,31 @@ const PITCH_CLASS_NUMBER_TO_PITCH_NAME = {
   11: 'B',
 };
 
-export function toPitchClassNumber(noteNumber) {
-  return Math.floor(noteNumber % 12);
-}
+export const toPitchClassNumber = noteNumber => Math.floor(noteNumber % 12);
 
-export function toOctaveNumber(noteNumber) {
-  return Math.floor(noteNumber / 12) - 1;
-}
+export const toOctaveNumber = noteNumber => Math.floor(noteNumber / 12) - 1;
 
-export function toPitchClassName(noteNumber) {
-  return PITCH_CLASS_NUMBER_TO_PITCH_NAME[toPitchClassNumber(noteNumber)];
-}
+export const toPitchClassName = noteNumber =>
+  PITCH_CLASS_NUMBER_TO_PITCH_NAME[toPitchClassNumber(noteNumber)];
 
-export function toHelmholtzCommas(noteNumber) {
+export const toHelmholtzCommas = noteNumber => {
   const numCommas = Math.max((-1 * toOctaveNumber(noteNumber)) + 2, 0);
   return new Array(numCommas).fill(',').join('');
-}
+};
 
-export function toHelmholtzApostrophes(noteNumber) {
+export const toHelmholtzApostrophes = noteNumber => {
   const numApostrophes = Math.max(toOctaveNumber(noteNumber) - 3, 0);
   return new Array(numApostrophes).fill('\'').join('');
-}
+};
 
-export function toHelmholtzPitchName(noteNumber) {
-  if (noteNumber >= 48) return toPitchClassName(noteNumber).toLowerCase();
-  return toPitchClassName(noteNumber);
-}
+export const toHelmholtzPitchName = noteNumber =>
+  noteNumber >= 48
+    ? toPitchClassName(noteNumber).toLowerCase()
+    : toPitchClassName(noteNumber);
 
 
-export function toHelmholtzPitch(noteNumber) {
-  return `${toHelmholtzPitchName(noteNumber)}${toHelmholtzCommas(noteNumber)}${toHelmholtzApostrophes(noteNumber)}`;
-}
+export const toHelmholtzPitch = noteNumber =>
+  `${toHelmholtzPitchName(noteNumber)}${toHelmholtzCommas(noteNumber)}${toHelmholtzApostrophes(noteNumber)}`;
 
-export function toScientificPitch(noteNumber) {
-  return `${toPitchClassName(noteNumber)}${toOctaveNumber(noteNumber)}`;
-}
+export const toScientificPitch = noteNumber =>
+  `${toPitchClassName(noteNumber)}${toOctaveNumber(noteNumber)}`;

--- a/src/mpeInstrument/utils/objectUtils.js
+++ b/src/mpeInstrument/utils/objectUtils.js
@@ -1,4 +1,4 @@
-export function transformObject(object, transformations={}) {
+export const transformObject = (object, transformations={}) => {
   const changedValues = Object.keys(transformations).reduce((acc, key) => {
     if (typeof object[key] !== 'undefined') {
       acc[key] = transformations[key](object[key]);
@@ -7,4 +7,4 @@ export function transformObject(object, transformations={}) {
   }, {});
 
   return Object.assign({}, object, changedValues);
-}
+};

--- a/src/mpeInstrument/utils/statusByteUtils.js
+++ b/src/mpeInstrument/utils/statusByteUtils.js
@@ -22,5 +22,5 @@ export const statusByteClassifier = statusByte => {
   return types.UNCLASSIFIED;
 };
 
-export const statusByteToChannel = (statusByte) =>
+export const statusByteToChannel = statusByte =>
   (statusByte & 0x0f) + 1;

--- a/src/mpeInstrument/utils/statusByteUtils.js
+++ b/src/mpeInstrument/utils/statusByteUtils.js
@@ -7,7 +7,7 @@
 
 import * as types from '../constants/midiMessageTypes';
 
-export function statusByteClassifier(statusByte) {
+export const statusByteClassifier = statusByte => {
   const firstNibble = statusByte & 0xf0;
   switch (firstNibble) {
     case 0x80: return types.NOTE_OFF;
@@ -20,8 +20,7 @@ export function statusByteClassifier(statusByte) {
     case 0xf0: return types.SYSTEM_MESSAGE;
   }
   return types.UNCLASSIFIED;
-}
+};
 
-export function statusByteToChannel(statusByte) {
-  return (statusByte & 0x0f) + 1;
-}
+export const statusByteToChannel = (statusByte) =>
+  (statusByte & 0x0f) + 1;

--- a/src/sandbox.js
+++ b/src/sandbox.js
@@ -26,7 +26,7 @@ if (navigator.requestMIDIAccess) {
       const recorder = new mpe.recorder();
       recorder.debug();
     },
-    (error) => {
+    error => {
       console.log('requestMIDIAccess failed.');
       console.error(error);
     }

--- a/test/functional/mpeInstrument.test.js
+++ b/test/functional/mpeInstrument.test.js
@@ -128,79 +128,87 @@ describe('mpeInstrument', () => {
         instrument.processMidiMessage(NOTE_OFF_1);
         expect(instrument.activeNotes().length).to.eq(0);
       });
-    });
-  });
-  describe('pitch', () => {
-    const noteOn = noteNumber => new Uint8Array([0x91, noteNumber, 127]);
-    const EXPECTED_PITCH_CONVERSIONS = [
-      { noteNumber: 0,   scientific: 'C-1',  helmholtz: 'C,,,' },
-      { noteNumber: 1,   scientific: 'C#-1', helmholtz: 'C#,,,' },
-      { noteNumber: 60,  scientific: 'C4',   helmholtz: 'c\'' },
-      { noteNumber: 63,  scientific: 'Eb4',  helmholtz: 'eb\'' },
-      { noteNumber: 66,  scientific: 'F#4',  helmholtz: 'f#\'' },
-      { noteNumber: 69,  scientific: 'A4',   helmholtz: 'a\'' },
-      { noteNumber: 127, scientific: 'G9',   helmholtz: 'g\'\'\'\'\'\'' },
-    ];
-    describe('true', () => {
-      beforeEach(() => {
-        instrument = mpeInstrument({ pitch: true });
-      });
-      it('should add pitch string to active notes', () => {
-        instrument.processMidiMessage(NOTE_ON_1);
+      it('should normalize channel scope midi messages', () => {
+        instrument.processMidiMessage(TIMBRE);
+        instrument.processMidiMessage(PITCH_BEND);
         instrument.processMidiMessage(NOTE_ON_2);
-        expect(instrument.activeNotes().every(n => typeof n.pitch === 'string')).to.be.true;
+        console.log(instrument.activeNotes())
+        expect(instrument.activeNotes()[0].timbre).to.eq(1);
+        expect(instrument.activeNotes()[0].pitchBend).to.eq(1);
       });
-      it('should alias pitch \'scientific\'', () => {
-        const instruments = [instrument, mpeInstrument({ pitch: 'scientific' })];
-        EXPECTED_PITCH_CONVERSIONS.forEach(({ noteNumber, scientific }) => {
-          instruments.forEach(i => i.processMidiMessage(noteOn(noteNumber)));
-          expect(instruments[0].activeNotes()[0].pitch).to.eq(instruments[0].activeNotes()[0].pitch);
-          instruments.forEach(i => i.clear());
+    });
+    describe('pitch', () => {
+      const noteOn = noteNumber => new Uint8Array([0x91, noteNumber, 127]);
+      const EXPECTED_PITCH_CONVERSIONS = [
+        { noteNumber: 0,   scientific: 'C-1',  helmholtz: 'C,,,' },
+        { noteNumber: 1,   scientific: 'C#-1', helmholtz: 'C#,,,' },
+        { noteNumber: 60,  scientific: 'C4',   helmholtz: 'c\'' },
+        { noteNumber: 63,  scientific: 'Eb4',  helmholtz: 'eb\'' },
+        { noteNumber: 66,  scientific: 'F#4',  helmholtz: 'f#\'' },
+        { noteNumber: 69,  scientific: 'A4',   helmholtz: 'a\'' },
+        { noteNumber: 127, scientific: 'G9',   helmholtz: 'g\'\'\'\'\'\'' },
+      ];
+      describe('true', () => {
+        beforeEach(() => {
+          instrument = mpeInstrument({ pitch: true });
+        });
+        it('should add pitch string to active notes', () => {
+          instrument.processMidiMessage(NOTE_ON_1);
+          instrument.processMidiMessage(NOTE_ON_2);
+          expect(instrument.activeNotes().every(n => typeof n.pitch === 'string')).to.be.true;
+        });
+        it('should alias pitch \'scientific\'', () => {
+          const instruments = [instrument, mpeInstrument({ pitch: 'scientific' })];
+          EXPECTED_PITCH_CONVERSIONS.forEach(({ noteNumber, scientific }) => {
+            instruments.forEach(i => i.processMidiMessage(noteOn(noteNumber)));
+            expect(instruments[0].activeNotes()[0].pitch).to.eq(instruments[0].activeNotes()[0].pitch);
+            instruments.forEach(i => i.clear());
+          });
         });
       });
-    });
-    describe('\'scientific\'', () => {
-      beforeEach(() => {
-        instrument = mpeInstrument({ pitch: 'scientific' });
-      });
-      it('should add pitch string to active notes', () => {
-        instrument.processMidiMessage(NOTE_ON_1);
-        instrument.processMidiMessage(NOTE_ON_2);
-        expect(instrument.activeNotes().every(n => typeof n.pitch === 'string')).to.be.true;
-      });
-      it('should match expected results', () => {
-        EXPECTED_PITCH_CONVERSIONS.forEach(({ noteNumber, scientific }) => {
-          instrument.processMidiMessage(noteOn(noteNumber));
-          expect(instrument.activeNotes()[0].pitch).to.eq(scientific);
-          instrument.clear();
+      describe('\'scientific\'', () => {
+        beforeEach(() => {
+          instrument = mpeInstrument({ pitch: 'scientific' });
+        });
+        it('should add pitch string to active notes', () => {
+          instrument.processMidiMessage(NOTE_ON_1);
+          instrument.processMidiMessage(NOTE_ON_2);
+          expect(instrument.activeNotes().every(n => typeof n.pitch === 'string')).to.be.true;
+        });
+        it('should match expected results', () => {
+          EXPECTED_PITCH_CONVERSIONS.forEach(({ noteNumber, scientific }) => {
+            instrument.processMidiMessage(noteOn(noteNumber));
+            expect(instrument.activeNotes()[0].pitch).to.eq(scientific);
+            instrument.clear();
+          });
         });
       });
-    });
-    describe('\'helmholtz\'', () => {
-      beforeEach(() => {
-        instrument = mpeInstrument({ pitch: 'helmholtz' });
-      });
-      it('should add pitch string to active notes', () => {
-        instrument.processMidiMessage(NOTE_ON_1);
-        instrument.processMidiMessage(NOTE_ON_2);
-        expect(instrument.activeNotes().every(n => typeof n.pitch === 'string')).to.be.true;
-      });
-      it('should match expected results', () => {
-        EXPECTED_PITCH_CONVERSIONS.forEach(({ noteNumber, helmholtz }) => {
-          instrument.processMidiMessage(noteOn(noteNumber));
-          expect(instrument.activeNotes()[0].pitch).to.eq(helmholtz);
-          instrument.clear();
+      describe('\'helmholtz\'', () => {
+        beforeEach(() => {
+          instrument = mpeInstrument({ pitch: 'helmholtz' });
+        });
+        it('should add pitch string to active notes', () => {
+          instrument.processMidiMessage(NOTE_ON_1);
+          instrument.processMidiMessage(NOTE_ON_2);
+          expect(instrument.activeNotes().every(n => typeof n.pitch === 'string')).to.be.true;
+        });
+        it('should match expected results', () => {
+          EXPECTED_PITCH_CONVERSIONS.forEach(({ noteNumber, helmholtz }) => {
+            instrument.processMidiMessage(noteOn(noteNumber));
+            expect(instrument.activeNotes()[0].pitch).to.eq(helmholtz);
+            instrument.clear();
+          });
         });
       });
-    });
-    describe('false', () => {
-      beforeEach(() => {
-        instrument = mpeInstrument({ pitch: false });
-      });
-      it('should leave active note pitch property undefined', () => {
-        instrument.processMidiMessage(NOTE_ON_1);
-        instrument.processMidiMessage(NOTE_ON_2);
-        expect(instrument.activeNotes().every(n => typeof n.pitch === 'undefined')).to.be.true;
+      describe('false', () => {
+        beforeEach(() => {
+          instrument = mpeInstrument({ pitch: false });
+        });
+        it('should leave active note pitch property undefined', () => {
+          instrument.processMidiMessage(NOTE_ON_1);
+          instrument.processMidiMessage(NOTE_ON_2);
+          expect(instrument.activeNotes().every(n => typeof n.pitch === 'undefined')).to.be.true;
+        });
       });
     });
   });

--- a/test/unit/noteNumberUtils.test.js
+++ b/test/unit/noteNumberUtils.test.js
@@ -1,20 +1,23 @@
 import { expect } from 'chai';
 import { toScientificPitch, toHelmholtzPitch } from '../../src/mpeInstrument/utils/noteNumberUtils';
 import noteNumberToPitch from '../data/noteNumberToPitch';
+import { log } from 'mocha-logger';
 
 describe('noteNumberUtils', () => {
   describe('toScientificPitch()', () => {
-    noteNumberToPitch.forEach(({ noteNumber, scientific }, i) => {
-      it(`converts note number ${noteNumber} to ${scientific}`, () => {
+    it('converts note numbers to scientific pitch', () => {
+      log(noteNumberToPitch.map(({ noteNumber, scientific }, i) => {
         expect(toScientificPitch(noteNumber)).to.eq(scientific);
-      });
+        return `${noteNumber} ${scientific}`;
+      }).join(' | '));
     });
   });
   describe('toHelmholtzPitch()', () => {
-    noteNumberToPitch.forEach(({ noteNumber, helmholtz }, i) => {
-      it(`converts note number ${noteNumber} to ${helmholtz}`, () => {
+    it('converts note numbers to helmholtz pitch', () => {
+      log(noteNumberToPitch.map(({ noteNumber, helmholtz }, i) => {
         expect(toHelmholtzPitch(noteNumber)).to.eq(helmholtz);
-      });
+        return `${noteNumber} ${helmholtz}`;
+      }).join(' | '));
     });
   });
 });


### PR DESCRIPTION
Turns out using redux middleware _was_ an over engineered solution for converting note properties after all. Although all values set by actions were being correctly converted, defaults in the reducers weren't.

So I've switched to:
* keeping only raw MIDI values in the redux state
* using comparison with previous state to check for updates (as before)
* running the raw active notes through a formatter (`formatActiveNotes`) just before they are shown to the user

All this clears the way for adding functionality like this more easily: https://github.com/WeAreROLI/mpejs/issues/29