### PR TITLE
Fix confusing Note

### DIFF
--- a/docs/documentation.yml
+++ b/docs/documentation.yml
@@ -18,7 +18,7 @@ toc:
       * Script tag
       <pre class='p1 mb1'>&lt;script src='path/to/mpe/lib/mpe.min.js'>&lt;/script></pre>
 
-      <small>*Note*: Using `lib/mpe.min.js` or `lib/mpe.min.js` via a script tag will assign
+      <small>*Note*: Using `lib/mpe.js` or `lib/mpe.min.js` via a script tag will assign
       module contents to `window.mpe`.</small>"
 
   - name: API


### PR DESCRIPTION
There appear to be two script tags:

* https://unpkg.com/mpe@1.0.1/lib/mpe.js
* https://unpkg.com/mpe@1.0.1/lib/mpe.min.js

But the Note uses `mpe.min.js` for both file names ... which blew my mind for a second there, until I figured out it was probably copy pasta :P